### PR TITLE
Start to incorporate Xilinx device TAP recognition

### DIFF
--- a/src/jtag/core.c
+++ b/src/jtag/core.c
@@ -372,8 +372,20 @@ static void jtag_add_ir_scan_noverify_callback(struct jtag_tap *active,
 /* If fields->in_value is filled out, then the captured IR value will be checked */
 void jtag_add_ir_scan(struct jtag_tap *active, struct scan_field *in_fields, tap_state_t state)
 {
+  int ir;
+  ir = in_fields->out_value[0] & 0x3F;
+  
 	assert(state != TAP_RESET);
 
+  switch(ir)
+          {
+          case 0x2: LOG_DEBUG("USERID selected\n"); break;
+          case 0x9: LOG_DEBUG("IDCODE selected\n"); break;
+          case 0x22: LOG_DEBUG("DTMCS selected\n"); break;
+          case 0x23: LOG_DEBUG("DMI selected\n"); break;
+          default: LOG_DEBUG("IR %d selected\n", ir); abort(); break;
+          }
+        
 	if (jtag_verify && jtag_verify_capture_ir) {
 		/* 8 x 32 bit id's is enough for all invocations */
 
@@ -1069,12 +1081,16 @@ static bool jtag_examine_chain_check(uint8_t *idcodes, unsigned count)
 static void jtag_examine_chain_display(enum log_levels level, const char *msg,
 	const char *name, uint32_t idcode)
 {
+  extern int xilinx;
+  unsigned int mfg = (unsigned int)EXTRACT_MFG(idcode);
+  xilinx = mfg == 0x049;
+  
 	log_printf_lf(level, __FILE__, __LINE__, __func__,
 		"JTAG tap: %s %16.16s: 0x%08x "
 		"(mfg: 0x%3.3x (%s), part: 0x%4.4x, ver: 0x%1.1x)",
 		name, msg,
 		(unsigned int)idcode,
-		(unsigned int)EXTRACT_MFG(idcode),
+		mfg,
 		jep106_manufacturer(EXTRACT_JEP106_BANK(idcode), EXTRACT_JEP106_ID(idcode)),
 		(unsigned int)EXTRACT_PART(idcode),
 		(unsigned int)EXTRACT_VER(idcode));

--- a/src/target/riscv/debug_defines.h
+++ b/src/target/riscv/debug_defines.h
@@ -92,7 +92,7 @@
 #define DTM_DTMCS_VERSION_OFFSET            0
 #define DTM_DTMCS_VERSION_LENGTH            4
 #define DTM_DTMCS_VERSION                   (0xf << DTM_DTMCS_VERSION_OFFSET)
-#define DTM_DMI                             0x11
+#define DTM_DMI                             (xilinx ? 0x23 : 0x11)
 /*
 * Address used for DMI access. In Update-DR this value is used
 * to access the DM over the DMI.

--- a/src/target/riscv/riscv-013.c
+++ b/src/target/riscv/riscv-013.c
@@ -240,7 +240,7 @@ bool supports_extension(struct target *target, char letter)
 
 static void select_dmi(struct target *target)
 {
-	static uint8_t ir_dmi[1] = {DTM_DMI};
+	uint8_t ir_dmi[1] = {DTM_DMI};
 	struct scan_field field = {
 		.num_bits = target->tap->ir_length,
 		.out_value = ir_dmi,
@@ -260,7 +260,7 @@ static uint32_t dtmcontrol_scan(struct target *target, uint32_t out)
 
 	buf_set_u32(out_value, 0, 32, out);
 
-	jtag_add_ir_scan(target->tap, &select_dtmcontrol, TAP_IDLE);
+	jtag_add_ir_scan(target->tap, select_dtmcontrol(target), TAP_IDLE);
 
 	field.num_bits = 32;
 	field.out_value = out_value;

--- a/src/target/riscv/riscv.c
+++ b/src/target/riscv/riscv.c
@@ -85,13 +85,11 @@
 
 /*** JTAG registers. ***/
 
-#define DTMCONTROL					0x10
 #define DTMCONTROL_DBUS_RESET		(1<<16)
 #define DTMCONTROL_IDLE				(7<<10)
 #define DTMCONTROL_ADDRBITS			(0xf<<4)
 #define DTMCONTROL_VERSION			(0xf)
 
-#define DBUS						0x11
 #define DBUS_OP_START				0
 #define DBUS_OP_SIZE				2
 typedef enum {
@@ -170,21 +168,40 @@ enum {
 #define MAX_HWBPS			16
 #define DRAM_CACHE_SIZE		16
 
-uint8_t ir_dtmcontrol[1] = {DTMCONTROL};
-struct scan_field select_dtmcontrol = {
-       .in_value = NULL,
-       .out_value = ir_dtmcontrol
-};
-uint8_t ir_dbus[1] = {DBUS};
-struct scan_field select_dbus = {
-       .in_value = NULL,
-       .out_value = ir_dbus
-};
-uint8_t ir_idcode[1] = {0x1};
-struct scan_field select_idcode = {
-       .in_value = NULL,
-       .out_value = ir_idcode
-};
+int xilinx; // 1 if we use FPGA JTAG
+
+struct scan_field *select_dtmcontrol(struct target *target)
+{
+  static struct scan_field select;
+  static uint8_t ir_dtmcontrol[1];
+  ir_dtmcontrol[0] = (xilinx ? 0x22 : 0x10);
+  select.in_value = NULL;
+  select.out_value = ir_dtmcontrol;
+  select.num_bits = target->tap->ir_length;
+  return &select;
+}
+
+struct scan_field *select_dbus(struct target *target)
+{
+  static struct scan_field select;
+  static uint8_t ir_dbus[1];
+  ir_dbus[0] = (xilinx ? 0x23 : 0x11);
+  select.in_value = NULL;
+  select.out_value = ir_dbus;
+  select.num_bits = target->tap->ir_length;
+  return &select;
+}
+
+struct scan_field *select_idcode(struct target *target)
+{
+  static struct scan_field select;
+  static uint8_t ir_idcode[1];
+  ir_idcode[0] = (xilinx ? 0x9 : 0x1);
+  select.in_value = NULL;
+  select.out_value = ir_idcode;
+  select.num_bits = target->tap->ir_length;
+  return &select;
+}
 
 struct trigger {
 	uint64_t address;
@@ -203,7 +220,7 @@ static uint32_t dtmcontrol_scan(struct target *target, uint32_t out)
 
 	buf_set_u32(out_value, 0, 32, out);
 
-	jtag_add_ir_scan(target->tap, &select_dtmcontrol, TAP_IDLE);
+	jtag_add_ir_scan(target->tap, select_dtmcontrol(target), TAP_IDLE);
 
 	field.num_bits = 32;
 	field.out_value = out_value;
@@ -211,7 +228,7 @@ static uint32_t dtmcontrol_scan(struct target *target, uint32_t out)
 	jtag_add_dr_scan(target->tap, 1, &field, TAP_IDLE);
 
 	/* Always return to dbus. */
-	jtag_add_ir_scan(target->tap, &select_dbus, TAP_IDLE);
+	jtag_add_ir_scan(target->tap, select_dbus(target), TAP_IDLE);
 
 	int retval = jtag_execute_queue();
 	if (retval != ERROR_OK) {
@@ -249,10 +266,6 @@ static int riscv_init_target(struct command_context *cmd_ctx,
 		return ERROR_FAIL;
 	riscv_info_t *info = (riscv_info_t *) target->arch_info;
 	info->cmd_ctx = cmd_ctx;
-
-	select_dtmcontrol.num_bits = target->tap->ir_length;
-	select_dbus.num_bits = target->tap->ir_length;
-	select_idcode.num_bits = target->tap->ir_length;
 
 	return ERROR_OK;
 }

--- a/src/target/riscv/riscv.h
+++ b/src/target/riscv/riscv.h
@@ -12,6 +12,8 @@ struct riscv_program;
 #define RISCV_MAX_REGISTERS 5000
 #define RISCV_MAX_TRIGGERS 32
 
+extern int xilinx;
+
 extern struct target_type riscv011_target;
 extern struct target_type riscv013_target;
 
@@ -100,12 +102,9 @@ static inline riscv_info_t *riscv_info(const struct target *target)
 { return target->arch_info; }
 #define RISCV_INFO(R) riscv_info_t *R = riscv_info(target);
 
-extern uint8_t ir_dtmcontrol[1];
-extern struct scan_field select_dtmcontrol;
-extern uint8_t ir_dbus[1];
-extern struct scan_field select_dbus;
-extern uint8_t ir_idcode[1];
-extern struct scan_field select_idcode;
+struct scan_field *select_dtmcontrol(struct target *target);
+struct scan_field *select_dbus(struct target *target);
+struct scan_field *select_idcode(struct target *target);
 
 /*** OpenOCD Interface */
 int riscv_openocd_poll(struct target *target);


### PR DESCRIPTION
These changes are to allow the limited choice of IR codes that Xilinx provides on its Artix-7 range, and change the IR length to 6-bits.